### PR TITLE
Upgrade VAPI model from Haiku 4.5 to Sonnet 4.6

### DIFF
--- a/modal_readonly/tony_assistant_spec.json
+++ b/modal_readonly/tony_assistant_spec.json
@@ -9,7 +9,7 @@
 			"model": "eleven_flash_v2_5"
 		},
 		"model": {
-			"model": "claude-haiku-4-5-20251001",
+			"model": "claude-sonnet-4-6",
 			"provider": "anthropic",
 			"tools": [
 				{


### PR DESCRIPTION
## Summary
- Upgrade Tony's VAPI model from `claude-haiku-4-5-20251001` to `claude-sonnet-4-6`
- Expects improved conversation quality at higher cost/latency tradeoff

## Test plan
- [ ] Deploy to dev with `just run-dev-server`
- [ ] Test assistant endpoint with `just test-assistant-dev`
- [ ] Make a test call to verify VAPI accepts the model ID
- [ ] If VAPI rejects, fall back to `claude-sonnet-4-5-20250929`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI model powering Tony's assistant for improved performance and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->